### PR TITLE
Update php version for D8

### DIFF
--- a/islandora_basic_collection.info.yml
+++ b/islandora_basic_collection.info.yml
@@ -5,5 +5,5 @@ dependencies:
 package: 'Islandora Solution Packs'
 configure: islandora_basic_collection.admin
 core: 8.x
-php: '5.5.9'
+php: '7.2'
 type: module


### PR DESCRIPTION
php 5 support is being dropped:
[Drupal docs](https://www.drupal.org/docs/8/system-requirements/php-requirements)